### PR TITLE
Polymer one array mutation

### DIFF
--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -135,9 +135,9 @@
               <!-- Output -->
             </div>
             <!-- for components with settings (all non-resizables?) -->
-            <template is="dom-if" if="{{computeIf(el)}}">
+            <template is="dom-if" if="{{!el.resizable}}">
 
-              <iron-icon icon="settings" collapse-id="{{computeCollapseId(el)}}" component-id="{{el.id}}" on-click="toggleSetting" class$="{{computeClass(el)}}"></iron-icon>
+              <iron-icon icon="settings" collapse-id="{{computeCollapseId(el)}}" component-id="{{el.id}}" on-click="toggleSetting" class="setting-btn"></iron-icon>
 
             </template>
             <!-- for resizable components-->
@@ -874,7 +874,8 @@
       this._drawConnections();
     },
     toggleSetting: function (e, detail, selection) {
-      var button = e.path[0], componentId = button.componentId, elementInfo = this.findElById(componentId);
+      var button = e.target, componentId = button.componentId, elementInfo = this.findElById(componentId);
+      button.toggleClass('open');
       elementInfo.settingOpen = !elementInfo.settingOpen;
     },
     keydownHandler: function (e) {
@@ -1326,9 +1327,7 @@
     computeClass: function (el, ins) {
       return el.element.id + '-' + ins + ' arrow in-arrow';
     },
-    computeClass: function (el) {
-      return 'setting-btn ' + this.tokenList({ open: el.settingOpen });
-    },
+
     computeCollapseId: function (el) {
       return 'collapse-' + el.id;
     },
@@ -1338,11 +1337,10 @@
     computeClass: function (el) {
       return el.element.id + ' arrow out-arrow';
     },
-    // computeId: function (el) {
-    //   return 'collapse-' + el.id;
-    // },
+
+    // to do: update style values
     computeCollapseStyle: function (el) {
-      return 'top: ' + el.top + 35 + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
+      return 'top: ' + (el.top + 35) + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
     },
     concatClassNames: function() {
       return 'wrapper';//arguments.join(' ');

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -32,9 +32,9 @@
       <span class="slideout-handle">settings</span>
       <div class="slideout-inner">
 
-        <iron-icon-button id="showDataBtn" class="active" icon="view-module" on-click="showDataBtn" alt="show component data">
+        <paper-icon-button id="showDataBtn" class="active" icon="view-module" on-click="showDataBtn" alt="show component data">
           <span>show component input/output</span>
-        </iron-icon-button>
+        </paper-icon-button>
   
        <!--
         <core-icon-button id="saveBtn" icon="save" on-click="{{showSaveDialog}}" alt="save">
@@ -108,13 +108,13 @@
 
       <!-- Components and connector dots --> 
 
-      <template is="dom-repeat" class="render-after-el" items="{{_elements}}" as="{{el}}"  index-as="index">
+      <template is="dom-repeat" class="render-after-el" items="{{_elements}}" as="el" index-as="index">
       <!-- el is not working ?!?! -->
 
-        <div id="{{computeWrapperId(index)}}" component-id="{{computeElementId(index)}}" on-click="wrapperClicked" on-dragstart="dragStartWrapper" on-drag="dragWrapper" on-dragend="dragEndWrapper" draggable="true" class$="{{concatClassNames()}}" style$="{{computeWrapperStyles(index)}}">
+        <div id="{{computeWrapperId(el)}}" component-id="{{el.id}}" on-click="wrapperClicked" on-dragstart="dragStartWrapper" on-drag="dragWrapper" on-dragend="dragEndWrapper" draggable="true" class$="{{concatClassNames()}}" style$="{{computeWrapperStyles(el)}}">
 
-          <label>{{computeElementId(index)}}</label>
-          <div class="deleteEl" component_id="[[computeElementId(index)]]" on-click="_deleteElementEvent">X</div>
+          <label>{{el.id}}</label>
+          <div class="deleteEl" component_id="{{el.id}}" on-click="_deleteElementEvent">X</div>
 
             
             <div class="connectors-in">
@@ -159,7 +159,7 @@
         </div>
 
         <template is="dom-if" if="{{computeIf(el)}}">
-          <iron-collapse class="settings-collapse" id="{{computeCollapseId(el)}}" opened="{{el.settingOpen}}" style$="{{computeStyle(el)}}">
+          <iron-collapse class="settings-collapse" id="{{computeCollapseId(el)}}" opened="{{el.settingOpen}}" style$="{{computeCollapseStyle(el)}}">
             <content select="{{computeSelect(el)}}"></content>
           </iron-collapse>
         </template>
@@ -310,13 +310,12 @@
       }.bind(this));
     },
     _renderContainerTemplate: function() {
-        if(!this._containerTemplates)
-        this._containerTemplates = Polymer.dom(this.root).querySelectorAll('.render-after-el');
-        [].forEach.call(this._containerTemplates, function(item) {
-          console.log('rendering', item);
-          item.render();
-        });
-
+      if(!this._containerTemplates)
+      this._containerTemplates = Polymer.dom(this.root).querySelectorAll('.render-after-el');
+      [].forEach.call(this._containerTemplates, function(item) {
+        // console.log('rendering', item);
+        item.render();
+      });
     },
     _processNewElement: function (newEl, top, left) {
       var id = this._generateUniqueId(newEl.tagName.toLowerCase());
@@ -351,7 +350,7 @@
     _deleteElementById: function (compId) {
       var self = this;
       var compId = compId;
-
+      console.log(compId);
       ////// temporarily removing the deleteDialog and deleteToggle
       // self.$.deleteDialog.toggle();  // set the delete callback
 
@@ -365,7 +364,7 @@
 
         // remove element from elements array (which removes it from the shadowDOM)
         var filteredEls = self._elements.filter(function (el) {
-          return typeof(el.element) !== 'undefined' && el.element.id !== compId;
+          return typeof(el.element) != 'undefined' && el.element.id !== compId;
         });
 
         self.set('_elements', filteredEls);
@@ -570,7 +569,6 @@
       this._drawConnections();
     },
     _updateWrapperLocation: function (e, target, dx, dy) {
-      console.log(dx, dy);
       // keep the dragged position in the data-x/data-y attributes, add snap residue from previous drag
       var x = (parseFloat(target.getAttribute('data-x')) || 0) + dx + (parseFloat(target.getAttribute('residue-x')) || 0);
       var y = (parseFloat(target.getAttribute('data-y')) || 0) + dy + (parseFloat(target.getAttribute('residue-y')) || 0);
@@ -582,6 +580,11 @@
       // translate the element. 
       // last dragMove call passes e.x=0 and e.y=0 which causes neg x,y values. this if avoids that
       if (e.x !== 0 || e.y !== 0) {
+
+        // store transform for the udpateStyle method
+        var componentId = e.target.componentId; //('component-id');
+        this.findElById(componentId).transform = 'translate(' + sx + 'px, ' + sy + 'px)';
+
         // update the position attributes, and transform to actually move the element
         target.style.transform = 'translate(' + sx + 'px, ' + sy + 'px)';
         target.setAttribute('data-x', sx);
@@ -1276,14 +1279,14 @@
     computeLengthEqualsZero: function(item) {
       return item.length === 0;
     },
-    computeWrapperId: function (index) {
+    computeWrapperId: function (el) {
       //console.log('id', el, el.id);
-      return 'wrapper-' + this._elements[index].id;
+      return 'wrapper-' + el.id;
     },
 
-    computeWrapperStyles: function (index) {
+    computeWrapperStyles: function (el) {
       console.log('computing styles');
-      return 'top: ' + this._elements[index].top + 'px; left: ' + this._elements[index].left + 'px; transform: ' + this._elements[index].transform + '; width: ' + this._elements[index].width + 'px; height: ' + this._elements[index].height + 'px';
+      return 'top: ' + el.top + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
     },
 
     computeWrapperClass: function (el) {
@@ -1313,12 +1316,7 @@
     computeIf: function (_selElement, _showDataTable) {
       return _showDataTable && _selElement.output && _selElement.output.length > 0;
     },
-    // computeId: function (el) {
-    //   return 'wrapper-' + el.id;
-    // },
-    // computeStyle: function (el) {
-    //   return 'top: ' + el.top + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
-    // },
+
     computeIf: function (el) {
       return !el.resizable;
     },
@@ -1343,11 +1341,8 @@
     // computeId: function (el) {
     //   return 'collapse-' + el.id;
     // },
-    // computeStyle: function (el) {
-    //   return 'top: ' + el.top + 35 + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
-    // },
-    computeSelect: function (el) {
-      return '#' + el.id;
+    computeCollapseStyle: function (el) {
+      return 'top: ' + el.top + 35 + 'px; left: ' + el.left + 'px; transform: ' + el.transform + '; width: ' + el.width + 'px; height: ' + el.height + 'px';
     },
     concatClassNames: function() {
       return 'wrapper';//arguments.join(' ');
@@ -1355,7 +1350,6 @@
     _elementsChanged: function() {
       console.log('elements changed!');
     }
-
 
   });
 </script>

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -371,8 +371,7 @@
         self.set('_elements', filteredEls);
 
         // remove elements from lens-connector 
-        var child = self.removeChild(embeddedEl);
-        console.log(child);
+        self.removeChild(embeddedEl);
       // };
     },
     removeAllConnectionsFromElement: function (elId) {
@@ -419,8 +418,11 @@
       e.preventDefault();
     },
     droppedInContainer: function (e, detail, selection) {
-      var self = this;  //dont know why this method is being called instead of resizedragend?!
+      var self = this;
       //dont know why this method is being called instead of resizedragend?!
+
+      e.preventDefault();
+
       if (e.path && e.path.length > 0 && e.path[0].classList.contains('resize') > 0) {
         self.dragResizeEnd(e, detail, selection);
       }
@@ -435,7 +437,6 @@
       }
     },
     clickInContainer: function (e) {
-      console.log(e);
       var className = e.toElement.className;
       if (className.baseVal && className.baseVal.indexOf('cnxn') > -1) {
         console.log('clicked on connection');
@@ -569,6 +570,7 @@
       this._drawConnections();
     },
     _updateWrapperLocation: function (e, target, dx, dy) {
+      console.log(dx, dy);
       // keep the dragged position in the data-x/data-y attributes, add snap residue from previous drag
       var x = (parseFloat(target.getAttribute('data-x')) || 0) + dx + (parseFloat(target.getAttribute('residue-x')) || 0);
       var y = (parseFloat(target.getAttribute('data-y')) || 0) + dy + (parseFloat(target.getAttribute('residue-y')) || 0);
@@ -603,7 +605,6 @@
       target.setAttribute('residue-y', 0);
     },
     wrapperClicked: function (e, detail, selection) {
-      return;
       var wrapperEl = e.currentTarget;
       var elementId = wrapperEl.id;
       elementId = elementId.substring(8, elementId.length);
@@ -625,8 +626,6 @@
     },
     // SVG drag events, also called on mousedown
     dragStartSVG: function (e, details, selection) {
-      console.log(e);
-      console.log('hi');  // clear this._selWrappers [TO DO: unless Shift is clicked]
       // clear this._selWrappers [TO DO: unless Shift is clicked]
       this._selWrappers = [];
       this._makeDragArea = true;
@@ -686,19 +685,13 @@
     },
     // handle selecting elements by their wrapper during drag
     dragOverWrapper: function (e, details, selection) {
-    }  // if (this._makeDragArea) {
-       //   if (!this._selectingElByDrag) {
-       //     this._selectingElByDrag = true;
-       //   }
-       //   console.log('drag over: ' + e.target.id);
-       // }
-,
     // if (this._makeDragArea) {
     //   if (!this._selectingElByDrag) {
     //     this._selectingElByDrag = true;
     //   }
     //   console.log('drag over: ' + e.target.id);
     // }
+    },
     // create a rectangle to show drag area
     _createDragArea: function (e) {
       var x = e.x / this._zoom, y = e.y / this._zoom;

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -85,9 +85,8 @@
 
         </template> 
         <iron-selector class="output-selector" selected="{{_outputComponents}}" valueattr="label" multi="true">
-          <template is="dom-repeat"  items="{{_elements}}" as="el" index-as="index">
+          <template is="dom-repeat"  items="{{_elements}}" as="el" index-as="index" observe="id">
             <div class="col" label="{{el.id}}">{{el.id}}</div>
-
           </template> 
         </iron-selector>
 
@@ -115,7 +114,7 @@
         <div id="{{computeWrapperId(index)}}" component-id="{{computeElementId(index)}}" on-click="wrapperClicked" on-dragstart="dragStartWrapper" on-drag="dragWrapper" on-dragend="dragEndWrapper" draggable="true" class$="{{concatClassNames()}}" style$="{{computeWrapperStyles(index)}}">
 
           <label>{{computeElementId(index)}}</label>
-          <div class="deleteEl" component_id="{{computeElementId(index)}}" on-click="_deleteElementEvent">X</div>
+          <div class="deleteEl" component_id="[[computeElementId(index)]]" on-click="_deleteElementEvent">X</div>
 
             
             <div class="connectors-in">
@@ -210,6 +209,8 @@
       _dragArea: { value: null },
       _elements: {
         type: Array,
+        observer: '_elementsChanged',
+        notify: true,
         value: function () {
           return [];
         }
@@ -287,15 +288,17 @@
     },
     ready: function () {
       this.focus();
-      this.tabIndex = 0;  // for testing:
-                          // window.ff = this;
+      this.tabIndex = 0;
+
+      // for testing:
+      window.ff = this;
+
       this.addEventListener('core-resize', function () {
         this._drawConnections();
       });
       this.$.zoomRange.value = this._zoom;
     },
-    // for testing:
-    // window.ff = this;
+
     addNewElToLens: function (newElName, left, top) {
       var newEl = document.createElement(newElName);
       this.$.component_list.checkAndImport(newEl, function () {
@@ -316,7 +319,9 @@
 
     },
     _processNewElement: function (newEl, top, left) {
-      newEl.id = this._generateUniqueId(newEl.tagName.toLowerCase());
+      var id = this._generateUniqueId(newEl.tagName.toLowerCase());
+      newEl.setAttribute('id', id);
+
       var elItem = {
         element: newEl,
         id: newEl.id,
@@ -332,33 +337,43 @@
         elItem.width = 250;
         elItem.height = 200;
       }
-      this._elements.push(elItem);
+
+      var newElements = this._elements.slice();
+      newElements.push(elItem);
+      this.set('_elements', newElements);
     },
     // when delete button is clicked
     _deleteElementEvent: function (e) {
       var self = this;
-      var compId = e.target.getAttribute('component_id');
+      var compId = e.target.component_id;
       self._deleteElementById(compId);
     },
     _deleteElementById: function (compId) {
       var self = this;
       var compId = compId;
-      self.$.deleteDialog.toggle();  // set the delete callback
-      // set the delete callback
-      self._deleteCallback = function () {
-        var ebmededEl = self.querySelector('#' + compId);
+
+      ////// temporarily removing the deleteDialog and deleteToggle
+      // self.$.deleteDialog.toggle();  // set the delete callback
+
+      // // set the delete callback
+      // self._deleteCallback = function () {
+        var embeddedEl = self.querySelector('#' + compId);
+
         var elInArray = self.findElById(compId);  //remove all connections
         //remove all connections
-        self.removeAllConnectionsFromElement(compId)  // remove element from elements array (which removes it from the shadowDOM)
-;
+        self.removeAllConnectionsFromElement(compId);  // remove element from elements array (which removes it from the shadowDOM)
+
         // remove element from elements array (which removes it from the shadowDOM)
         var filteredEls = self._elements.filter(function (el) {
-          return el.element.id !== compId;
+          return typeof(el.element) !== 'undefined' && el.element.id !== compId;
         });
-        self._elements = filteredEls;  // remove elements from lens-connector 
+
+        self.set('_elements', filteredEls);
+
         // remove elements from lens-connector 
-        self.removeChild(embeddedEl);
-      };
+        var child = self.removeChild(embeddedEl);
+        console.log(child);
+      // };
     },
     removeAllConnectionsFromElement: function (elId) {
       var goodConnections = this._connections.filter(function (conn, index) {
@@ -420,6 +435,7 @@
       }
     },
     clickInContainer: function (e) {
+      console.log(e);
       var className = e.toElement.className;
       if (className.baseVal && className.baseVal.indexOf('cnxn') > -1) {
         console.log('clicked on connection');
@@ -587,6 +603,7 @@
       target.setAttribute('residue-y', 0);
     },
     wrapperClicked: function (e, detail, selection) {
+      return;
       var wrapperEl = e.currentTarget;
       var elementId = wrapperEl.id;
       elementId = elementId.substring(8, elementId.length);
@@ -608,6 +625,7 @@
     },
     // SVG drag events, also called on mousedown
     dragStartSVG: function (e, details, selection) {
+      console.log(e);
       console.log('hi');  // clear this._selWrappers [TO DO: unless Shift is clicked]
       // clear this._selWrappers [TO DO: unless Shift is clicked]
       this._selWrappers = [];
@@ -1341,6 +1359,9 @@
     },
     concatClassNames: function() {
       return 'wrapper';//arguments.join(' ');
+    },
+    _elementsChanged: function() {
+      console.log('elements changed!');
     }
 
 

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -582,9 +582,8 @@
       // translate the element. 
       // last dragMove call passes e.x=0 and e.y=0 which causes neg x,y values. this if avoids that
       if (e.x !== 0 || e.y !== 0) {
-        var componentId = target.componentId;
-        this.findElById(componentId).transform = 'translate(' + sx + 'px, ' + sy + 'px)';  // update the posiion attributes
-        // update the posiion attributes
+        // update the position attributes, and transform to actually move the element
+        target.style.transform = 'translate(' + sx + 'px, ' + sy + 'px)';
         target.setAttribute('data-x', sx);
         target.setAttribute('data-y', sy);
         target.setAttribute('start-x', e.x);


### PR DESCRIPTION
- _elements update with this.set('_elements')
- droppedInContainer fix for firefox
- drag elements
- in dom-repeat, use `el` instead of `index`. Index was causing issues when an element was deleted from the array and the indexes changed
- toggle settings (in progress, not working yet but changes the classnames)
