### PR TITLE
Polymer one tweaks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "iron-selector": "PolymerElements/iron-selector#^1.0.0",
     "iron-collapse": "PolymerElements/iron-collapse#^1.0.0",
-    "lenses-component-list": "lenses/lenses-component-list"
+    "lenses-component-list": "git@github.com:lenses/lenses-component-list.git#polymerOne",
+    "lens-ui-dialog": "git@github.com:therewasaguy/lens-ui-dialog.git"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^2.0.0"

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -406,7 +406,7 @@
     },
     // if option key was pressed, clone the element when drag is done
     _cloneElement: function (e) {
-      var selection = this._findWrapperInPath(e);
+      var selection = e.target;
 
       // figure out the name of the element...
       var componentId = selection.componentId;
@@ -507,7 +507,7 @@
     },
     dragResize: function (e) {
       var self = this;
-      var wrapper = self._findWrapperInPath(e);
+      var wrapper = e.target.parentNode;
       // var wrapper = selection.parentNode;  //var styles = window.getComputedStyle(wrapper);
                                            // var wrapperTop = parseInt(styles.top.replace('px',''));
                                            // var wrapperLeft = parseInt(styles.left.replace('px',''));
@@ -1479,25 +1479,6 @@
     },
     _elementsChanged: function() {
       console.log('elements changed!');
-    },
-    /**
-     *  Helper function that takes an event, loops through the
-     *  event path until it finds the item with 'wrapper' in its
-     *  id, and returns that item.
-     *  
-     *  @param   {Event} event JavaScript Event fired from an event listener
-     *  @return  {HTMLElement}      HTMLElement with 'wrapper' in its id
-     *  @private
-     */
-    _findWrapperInPath: function(e) {
-      var path = e.path;
-      for (var i = 0; i < path.length; i++) {
-        var elem = path[i];
-        var id = elem.id;
-        if (id && id.indexOf('wrapper') > -1) {
-          return elem;
-        }
-      }
     }
 
   });

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -994,36 +994,25 @@
       // prevent backspace acting as browser back button
       // via http://stackoverflow.com/a/2768256/2994108
       var doPrevent = false;
-      if (e.keyCode === 8) {
-          var d = event.srcElement || event.target;
-          if (d.tagName.toUpperCase() === 'TEXTAREA'
-            ||
-            (d.tagName.toUpperCase() === 'INPUT' && 
-              (
-                d.type.toUpperCase() === 'TEXT' ||
-                d.type.toUpperCase() === 'PASSWORD' || 
-                d.type.toUpperCase() === 'FILE' || 
-                d.type.toUpperCase() === 'SEARCH' || 
-                d.type.toUpperCase() === 'EMAIL' || 
-                d.type.toUpperCase() === 'NUMBER' || 
-                d.type.toUpperCase() === 'DATE'
-              )
-            )
-          )
-          {
-            doPrevent = d.readOnly || d.disabled;
-          }
-          else {
-              doPrevent = true;
-          }
+      if (e.keyCode == 8) {
+        var rx = /INPUT|SELECT|TEXTAREA/i;
+
+        var d = e.srcElement || e.target;
+        if (rx.test(d.tagName.toUpperCase() )) {
+          doPrevent = d.readOnly || d.disabled;
+        } else {
+          doPrevent = true;
+        }
       }
       if (doPrevent) {
-          e.preventDefault();
+        e.preventDefault();
       }
 
       switch (e.keyCode) {
       // if deleteKey:
       case 8:
+        if (!doPrevent) return;
+
         // if bezier was selected, delete that. Otherwise, delete element
         if (self._highlightedConnection) {
           self._deleteBezier(e, self._highlightedConnection);

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -6,7 +6,7 @@
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../iron-collapse/iron-collapse.html">
 
-<!-- <link rel="import" href="../core-overlay/core-overlay.html"> -->
+<link rel="import" href="../lens-ui-dialog/lens-ui-dialog.html">
 
   <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <dom-module id="lenses-freeform">
@@ -177,21 +177,21 @@
       </template>
     </div>        -->
 
-    <iron-overlay-behavior autoclosedisabled="" id="deleteDialog" class="dialog size-position">
+    <lens-ui-dialog autoclosedisabled="" id="deleteDialog" class="dialog size-position" opened="true">
       <p>Are you sure you want to remove the selected item?</p>
       <div horizontal="" end-justified="" layout="">
-        <paper-icon-button icon="clear" dismissive="" on-click="_noDelete">
+        <paper-icon-button icon="clear" dismissive="" on-click="_noDelete"></paper-icon-button>
         <paper-icon-button icon="check" affirmative="" on-click="_yesDelete"></paper-icon-button>
       </paper-icon-button></div>
-    </iron-overlay-behavior>
+    </lens-ui-dialog>
 
     <!-- Title and Author fields + save action in dialog-->
-    <iron-overlay-behavior class="dialog" id="savedetails">
+    <lens-ui-dialog class="dialog" id="savedetails">
       <h1><paper-input label="Title of Lens" value="{{lensTitle}}"></paper-input></h1>
       <h3><paper-input label="Your Name" value="{{lensAuthor}}"></paper-input></h3>
       <paper-icon-button class="save" affirmative="" icon="check" ng-click="saveLens()" on-click="_saveLens">
       <paper-icon-button class="" dismissive="" icon="clear"></paper-icon-button> 
-    </paper-icon-button></iron-overlay-behavior>
+    </paper-icon-button></lens-ui-dialog>
 
 
   </template>
@@ -375,10 +375,10 @@
       var compId = compId;
       console.log(compId);
       ////// temporarily removing the deleteDialog and deleteToggle
-      // self.$.deleteDialog.toggle();  // set the delete callback
+      self.$.deleteDialog.toggle();  // set the delete callback
 
       // // set the delete callback
-      // self._deleteCallback = function () {
+      self._deleteCallback = function () {
         var embeddedEl = self.querySelector('#' + compId);
 
         var elInArray = self.findElById(compId);  //remove all connections
@@ -394,7 +394,7 @@
 
         // remove elements from lens-connector 
         self.removeChild(embeddedEl);
-      // };
+      };
     },
     removeAllConnectionsFromElement: function (elId) {
       var goodConnections = this._connections.filter(function (conn, index) {
@@ -990,16 +990,40 @@
     },
     keydownHandler: function (e) {
       var self = this;
-      var focusedArea = e.path['0'].localName;  // make sure it is not a text or input area
-      // make sure it is not a text or input area
-      if (focusedArea.indexOf('text') > -1 || focusedArea.indexOf('input') > 1) {
-        console.log('in a text area');
-        return;
+
+      // prevent backspace acting as browser back button
+      // via http://stackoverflow.com/a/2768256/2994108
+      var doPrevent = false;
+      if (e.keyCode === 8) {
+          var d = event.srcElement || event.target;
+          if (d.tagName.toUpperCase() === 'TEXTAREA'
+            ||
+            (d.tagName.toUpperCase() === 'INPUT' && 
+              (
+                d.type.toUpperCase() === 'TEXT' ||
+                d.type.toUpperCase() === 'PASSWORD' || 
+                d.type.toUpperCase() === 'FILE' || 
+                d.type.toUpperCase() === 'SEARCH' || 
+                d.type.toUpperCase() === 'EMAIL' || 
+                d.type.toUpperCase() === 'NUMBER' || 
+                d.type.toUpperCase() === 'DATE'
+              )
+            )
+          )
+          {
+            doPrevent = d.readOnly || d.disabled;
+          }
+          else {
+              doPrevent = true;
+          }
       }
-      switch (e.which) {
+      if (doPrevent) {
+          e.preventDefault();
+      }
+
+      switch (e.keyCode) {
       // if deleteKey:
       case 8:
-        console.log('delete key');  // if bezier was selected, delete that. Otherwise, delete element
         // if bezier was selected, delete that. Otherwise, delete element
         if (self._highlightedConnection) {
           self._deleteBezier(e, self._highlightedConnection);
@@ -1009,7 +1033,6 @@
             self._deleteElementById(_id);
           }
         }
-        e.preventDefault();
         e.stopPropagation();
         break;  // zoom with -_ (189) and += (187)
       // zoom with -_ (189) and += (187)

--- a/lenses-freeform.html
+++ b/lenses-freeform.html
@@ -1095,10 +1095,14 @@
           using lens-output-change works for output-input connection. might have better performance than observation
           but not a universal solution. lets try:
          */
-        
-        if(sourceField==='input' && targetField==='output') {
+
+        if(sourceField.indexOf('output') == 0 && targetField.indexOf('input') == 0) {
           listener = function(e) {
             console.log(e);
+
+            // find the actual output?
+            // var output = target.element.output;
+
             target.element[targetField] = e.detail;
           }
           source.element.addEventListener('lens-ouput-changed', listener);


### PR DESCRIPTION
- Dialogs: create and require (with bower) a simple lens-ui-dialog component that I would add to Lenses if it seems useful. This seemed like the easiest way to utilize the overlay-behavior 
- delete key fix so that you can use delete in text fields, otherwise use it to delete elements/connections but it won't accidentally exit the page
- remove `this._findWrapperInPath` in favor of e.target or e.parentNode which seems to work and is still not ideal but probably faster (suggested by @sepans )
- minor tweak for `lens-ouput-changed` so that it recognizes connections between output and components that have multiple inputs, like lens-data-zip which has `input-aux`. 
